### PR TITLE
Don't share a common EventEmitter across Vimeo instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
  * Module dependencies
  */
 
-var EventEmitter = require('events');
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
 var loadAPI = require('./lib/load-api');
 var prepareEmbed = require('./lib/prepare-embed');
 
@@ -30,7 +31,7 @@ function Vimeo(id) {
  * Mixin events
  */
 
-Vimeo.prototype = new EventEmitter();
+util.inherits(Vimeo, EventEmitter);
 
 /**
  * Play the video.


### PR DESCRIPTION
This fixes problem where each instance of the wrapper object would
receive player events e.g. play, pause.
